### PR TITLE
Add support for tagged Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: Build and Push Docker Images
 on:
   push:
     branches: ["main", "develop"]
+    tags:
+      - "v*.*.*"
   pull_request:
     branches: ["main"]
 
@@ -42,6 +44,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=commit-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Extract metadata for backend
@@ -53,6 +58,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=commit-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push frontend Docker image
@@ -88,6 +96,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=commit-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push indexer Docker image


### PR DESCRIPTION
Configure GitHub Actions workflow to build and push Docker images with semantic version tags when a release tag is created. Images will be tagged with full version, major.minor, and major version numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)