### PR TITLE
Add mypy type checking with django-stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
   lint:
     name: Lint & format
     runs-on: ubuntu-latest
+    env:
+      DJANGO_SECRET_KEY: ci-secret-key-not-used-in-prod
+      DJANGO_DEBUG: "True"
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/cityforge_test
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: poetry run ruff check .
       - name: Ruff format check
         run: poetry run ruff format --check .
+      - name: Mypy type check
+        run: poetry run mypy apps cityforge indexer tests
 
   test:
     name: Tests & migrations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,13 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      - id: mypy
+        name: mypy type check
+        entry: poetry run mypy apps cityforge indexer tests
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: semgrep-local
         name: semgrep (python & django)
         entry: poetry run semgrep

--- a/README.md
+++ b/README.md
@@ -57,8 +57,16 @@ poetry run pre-commit install
 poetry run pre-commit run --all-files
 ```
 
-The hook config runs `ruff`, `ruff-format`, and `semgrep` (with the `p/python`,
-`p/django`, and `p/security-audit` rule packs) on every commit.
+The hook config runs `ruff`, `ruff-format`, `mypy`, and `semgrep` (with the
+`p/python`, `p/django`, and `p/security-audit` rule packs) on every commit.
+Production source code is required to be fully type-annotated; test files are
+checked but not required to be fully annotated.
+
+### Type checking
+
+```bash
+poetry run mypy apps cityforge indexer tests
+```
 
 ### Run E2E tests
 

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 User = get_user_model()
 
 
-class CaptchaFormMixin:
+class CaptchaFormMixin(forms.Form):
     def __init__(
         self,
         *args,
@@ -21,7 +21,7 @@ class CaptchaFormMixin:
         self.fields["captcha_answer"].help_text = captcha_prompt or "Solve the challenge above."
 
     def clean_captcha_answer(self) -> str:
-        answer = (self.cleaned_data.get("captcha_answer") or "").strip()
+        answer = str(self.cleaned_data.get("captcha_answer") or "").strip()
         if not self._captcha_expected or answer != self._captcha_expected:
             raise ValidationError("Incorrect security check answer.")
         return answer
@@ -45,13 +45,13 @@ class RegisterForm(CaptchaFormMixin, forms.ModelForm):
         fields = ("email", "first_name", "last_name")
 
     def clean_email(self) -> str:
-        email = self.cleaned_data["email"].lower().strip()
+        email = str(self.cleaned_data["email"]).lower().strip()
         if User.objects.filter(email__iexact=email).exists():
             raise ValidationError("An account with that email already exists.")
         return email
 
     def clean(self):
-        cleaned = super().clean()
+        cleaned = super().clean() or {}
         p1 = cleaned.get("password1")
         p2 = cleaned.get("password2")
         if p1 and p2 and p1 != p2:
@@ -63,10 +63,10 @@ class RegisterForm(CaptchaFormMixin, forms.ModelForm):
                 self.add_error("password1", exc)
         return cleaned
 
-    def save(self, commit: bool = True) -> User:
+    def save(self, commit: bool = True):
         user = super().save(commit=False)
         # Password validated above via validate_password() in clean().
-        password = self.cleaned_data["password1"]
+        password = str(self.cleaned_data["password1"])
         user.set_password(  # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password
             password
         )
@@ -99,7 +99,7 @@ class ResetPasswordForm(CaptchaFormMixin, forms.Form):
     captcha_answer = forms.CharField(label="Security check")
 
     def clean(self):
-        cleaned = super().clean()
+        cleaned = super().clean() or {}
         p1 = cleaned.get("password1")
         p2 = cleaned.get("password2")
         if p1 and p2 and p1 != p2:

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from django import forms
-from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 
-User = get_user_model()
+from apps.accounts.models import User
 
 
 class CaptchaFormMixin(forms.Form):
     def __init__(
         self,
-        *args,
+        *args: Any,
         captcha_prompt: str | None = None,
         captcha_expected: str | None = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         self._captcha_expected = (captcha_expected or "").strip()
         super().__init__(*args, **kwargs)
         self.fields["captcha_answer"].help_text = captcha_prompt or "Solve the challenge above."
@@ -50,7 +51,7 @@ class RegisterForm(CaptchaFormMixin, forms.ModelForm):
             raise ValidationError("An account with that email already exists.")
         return email
 
-    def clean(self):
+    def clean(self) -> dict[str, Any]:
         cleaned = super().clean() or {}
         p1 = cleaned.get("password1")
         p2 = cleaned.get("password2")
@@ -63,8 +64,8 @@ class RegisterForm(CaptchaFormMixin, forms.ModelForm):
                 self.add_error("password1", exc)
         return cleaned
 
-    def save(self, commit: bool = True):
-        user = super().save(commit=False)
+    def save(self, commit: bool = True) -> User:
+        user = cast(User, super().save(commit=False))
         # Password validated above via validate_password() in clean().
         password = str(self.cleaned_data["password1"])
         user.set_password(  # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password
@@ -98,7 +99,7 @@ class ResetPasswordForm(CaptchaFormMixin, forms.Form):
     )
     captcha_answer = forms.CharField(label="Security check")
 
-    def clean(self):
+    def clean(self) -> dict[str, Any]:
         cleaned = super().clean() or {}
         p1 = cleaned.get("password1")
         p2 = cleaned.get("password2")

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -1,32 +1,36 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.db import models
 from django.utils import timezone
 
 
-class UserManager(BaseUserManager):
+class UserManager(BaseUserManager["User"]):
     use_in_migrations = True
 
-    def _create_user(self, email, password, **extra_fields):
+    def _create_user(self, email: str, password: str | None, **extra_fields: Any) -> User:
         if not email:
             raise ValueError("Email is required")
         email = self.normalize_email(email)
         user = self.model(email=email, **extra_fields)
         # Called from createsuperuser / data import; AUTH_PASSWORD_VALIDATORS
         # are not applied for these admin-driven flows by design.
-        user.set_password(  # type: ignore[attr-defined]  # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password
+        user.set_password(  # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password
             password
         )
         user.save(using=self._db)
         return user
 
-    def create_user(self, email, password=None, **extra_fields):
+    def create_user(self, email: str, password: str | None = None, **extra_fields: Any) -> User:
         extra_fields.setdefault("role", User.Role.USER)
         extra_fields.setdefault("is_active", True)
         return self._create_user(email, password, **extra_fields)
 
-    def create_superuser(self, email, password=None, **extra_fields):
+    def create_superuser(
+        self, email: str, password: str | None = None, **extra_fields: Any
+    ) -> User:
         extra_fields["role"] = User.Role.ADMIN
         extra_fields["is_staff"] = True
         extra_fields["is_superuser"] = True

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -15,7 +15,7 @@ class UserManager(BaseUserManager):
         user = self.model(email=email, **extra_fields)
         # Called from createsuperuser / data import; AUTH_PASSWORD_VALIDATORS
         # are not applied for these admin-driven flows by design.
-        user.set_password(  # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password
+        user.set_password(  # type: ignore[attr-defined]  # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password
             password
         )
         user.save(using=self._db)

--- a/apps/accounts/tests.py
+++ b/apps/accounts/tests.py
@@ -32,7 +32,7 @@ class AccountFlowTests(TestCase):
         )
 
     def _captcha_answer(self, scope: str) -> str:
-        return self.client.session[f"accounts_captcha:{scope}:answer"]
+        return str(self.client.session[f"accounts_captcha:{scope}:answer"])
 
     def _set_captcha(self, scope: str, answer: str = "7") -> None:
         session = self.client.session
@@ -346,7 +346,7 @@ class MobileAuthApiTests(TestCase):
         )
         token = login_response.json()["access_token"]
 
-        response = self.client.get("/api/auth/me", **self._auth_header(token))
+        response = self.client.get("/api/auth/me", **self._auth_header(token))  # type: ignore[arg-type]
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["email"], self.user.email)
@@ -359,11 +359,11 @@ class MobileAuthApiTests(TestCase):
         )
         token = login_response.json()["access_token"]
 
-        response = self.client.post("/api/auth/logout", **self._auth_header(token))
+        response = self.client.post("/api/auth/logout", **self._auth_header(token))  # type: ignore[arg-type]
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(TokenBlacklist.objects.count(), 1)
-        me_response = self.client.get("/api/auth/me", **self._auth_header(token))
+        me_response = self.client.get("/api/auth/me", **self._auth_header(token))  # type: ignore[arg-type]
         self.assertEqual(me_response.status_code, 401)
 
     def test_register_returns_access_token(self) -> None:

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -41,8 +41,8 @@ MOBILE_AUTH_TOKEN_TTL = timedelta(days=7)
 
 def _client_ip(request: HttpRequest) -> str | None:
     """Return the client IP, preferring REMOTE_ADDR and validating proxies."""
-    remote_addr = request.META.get("REMOTE_ADDR")
-    forwarded = request.META.get("HTTP_X_FORWARDED_FOR")
+    remote_addr = str(request.META.get("REMOTE_ADDR", "")) or None
+    forwarded = str(request.META.get("HTTP_X_FORWARDED_FOR", "")) or None
     # Only trust X-Forwarded-For when the request came through a known proxy.
     if (
         forwarded
@@ -148,7 +148,7 @@ def _serialize_user(user: User) -> dict[str, object]:
 
 
 def _auth_token_signing_key() -> bytes:
-    return settings.SECRET_KEY.encode()
+    return str(settings.SECRET_KEY).encode()
 
 
 def _encode_auth_token(payload: dict[str, object]) -> str:
@@ -504,7 +504,7 @@ def login_view(request: HttpRequest) -> HttpResponse:
                     require_https=request.is_secure(),
                 ):
                     next_url = reverse("directory:home")
-                return redirect(next_url)
+                return redirect(next_url or "directory:home")
     else:
         form = LoginForm()
     return render(request, "accounts/login.html", {"form": form})
@@ -619,7 +619,11 @@ def verify_email(request: HttpRequest, token: str) -> HttpResponse:
 @login_required
 @require_http_methods(["POST"])
 def resend_verification(request: HttpRequest) -> HttpResponse:
+    from django.contrib.auth.models import AnonymousUser
+
     user = request.user
+    if isinstance(user, AnonymousUser):
+        return redirect("accounts:login")
     if user.email_verified:
         messages.info(request, "Your email is already verified.")
     else:

--- a/apps/cms/decorators.py
+++ b/apps/cms/decorators.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from functools import wraps
+from typing import Any
 
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseForbidden
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 
 
-def staff_required(view_func):
+def staff_required(view_func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
     @wraps(view_func)
     @login_required
-    def _wrapped(request, *args, **kwargs):
+    def _wrapped(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         user = request.user
         if not (
             user.is_staff or getattr(user, "is_admin", False) or getattr(user, "is_support", False)
@@ -18,10 +22,10 @@ def staff_required(view_func):
     return _wrapped
 
 
-def admin_required(view_func):
+def admin_required(view_func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
     @wraps(view_func)
     @login_required
-    def _wrapped(request, *args, **kwargs):
+    def _wrapped(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         user = request.user
         if not (user.is_superuser or getattr(user, "is_admin", False)):
             return HttpResponseForbidden("Admin access required.")

--- a/apps/cms/tests.py
+++ b/apps/cms/tests.py
@@ -182,6 +182,7 @@ class CmsMutationTests(TestCase):
         self.submission.refresh_from_db()
         self.assertEqual(self.submission.status, CardSubmissionStatus.APPROVED)
         self.assertIsNotNone(self.submission.card)
+        assert self.submission.card is not None
         self.assertTrue(Tag.objects.filter(name="coffee").exists())
         mocked_dispatch.assert_called_once()
         self.assertEqual(mocked_dispatch.call_args.args[0], "submission.approved")

--- a/apps/cms/views.py
+++ b/apps/cms/views.py
@@ -146,6 +146,7 @@ def users_list(request: HttpRequest) -> HttpResponse:
 @admin_required
 @require_http_methods(["POST"])
 def user_toggle_active(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     user = get_object_or_404(User, pk=pk)
     if user.pk == request.user.pk:
         messages.error(request, "You cannot deactivate your own account.")
@@ -179,6 +180,7 @@ def user_toggle_active(request: HttpRequest, pk: int) -> HttpResponse:
 @admin_required
 @require_http_methods(["POST"])
 def user_set_role(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     user = get_object_or_404(User, pk=pk)
     role = request.POST.get("role", User.Role.USER)
     if role not in {r.value for r in User.Role}:
@@ -240,6 +242,7 @@ def cards_list(request: HttpRequest) -> HttpResponse:
 
 @staff_required
 def card_edit(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     card = get_object_or_404(Card, pk=pk)
     if request.method == "POST":
         form = CardModerationForm(request.POST, instance=card)
@@ -286,6 +289,7 @@ def card_edit(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def card_delete(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     card = get_object_or_404(Card, pk=pk)
     payload = {
         "card_id": card.id,
@@ -359,6 +363,7 @@ def event_submission_detail(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def event_submission_approve(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     submission = get_object_or_404(EventSubmission, pk=pk)
     if submission.status != EventSubmissionStatus.PENDING:
         messages.error(request, "Event submission already reviewed.")
@@ -411,6 +416,7 @@ def event_submission_approve(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def event_submission_reject(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     submission = get_object_or_404(EventSubmission, pk=pk)
     if submission.status != EventSubmissionStatus.PENDING:
         messages.error(request, "Event submission already reviewed.")
@@ -478,6 +484,7 @@ def modification_detail(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def submission_approve(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     sub = get_object_or_404(CardSubmission, pk=pk)
     if sub.status != CardSubmissionStatus.PENDING:
         messages.error(request, "Submission already reviewed.")
@@ -534,6 +541,7 @@ def submission_approve(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def submission_reject(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     sub = get_object_or_404(CardSubmission, pk=pk)
     if sub.status != CardSubmissionStatus.PENDING:
         messages.error(request, "Submission already reviewed.")
@@ -568,6 +576,7 @@ def submission_reject(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def modification_approve(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     mod = get_object_or_404(CardModification.objects.select_related("card"), pk=pk)
     if mod.status != CardSubmissionStatus.PENDING:
         messages.error(request, "Modification already reviewed.")
@@ -622,6 +631,7 @@ def modification_approve(request: HttpRequest, pk: int) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def modification_reject(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     mod = get_object_or_404(CardModification, pk=pk)
     if mod.status != CardSubmissionStatus.PENDING:
         messages.error(request, "Modification already reviewed.")
@@ -688,6 +698,7 @@ def reviews_list(request: HttpRequest) -> HttpResponse:
 @staff_required
 @require_http_methods(["POST"])
 def review_toggle_hidden(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     review = get_object_or_404(Review, pk=pk)
     review.hidden = not review.hidden
     review.save(update_fields=["hidden"])

--- a/apps/cms/views.py
+++ b/apps/cms/views.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.contrib import messages
 from django.core.paginator import Paginator
 from django.db.models import Count, Q
@@ -43,7 +45,7 @@ def _modification_comparison_rows(modification: CardModification) -> list[dict[s
     return modification_comparison_rows(modification)
 
 
-def _absolute_url(request: HttpRequest, view_name: str, **kwargs) -> str:
+def _absolute_url(request: HttpRequest, view_name: str, **kwargs: Any) -> str:
     return request.build_absolute_uri(reverse(view_name, kwargs=kwargs))
 
 

--- a/apps/core/cache_utils.py
+++ b/apps/core/cache_utils.py
@@ -10,6 +10,13 @@ from typing import Any
 from django.core.cache import cache
 
 
+def _get_cache(name: str):
+    backend = cache
+    if hasattr(cache, "get_client"):
+        return cache.get_client(name)
+    return backend
+
+
 def cache_key(*args, **kwargs) -> str:
     """Generate a cache key from arguments."""
     key_parts = list(args) + [f"{k}={v}" for k, v in sorted(kwargs.items())]
@@ -42,7 +49,7 @@ def cache_result(
         @wraps(func)
         def wrapper(*args, **kwargs) -> Any:
             # Build cache key
-            cache_obj = cache.get_client(cache_name)
+            cache_obj = _get_cache(cache_name)
             prefix = key_prefix or func.__name__
             key = f"{prefix}:{cache_key(*args, **kwargs)}"
 
@@ -71,10 +78,10 @@ def invalidate_cache(pattern: str, cache_name: str = "default") -> int:
     Returns:
         Number of keys deleted
     """
-    cache_obj = cache.get_client(cache_name)
+    cache_obj = _get_cache(cache_name)
     keys = cache_obj.keys(pattern)
     if keys:
-        return cache_obj.delete(*keys)
+        return int(cache_obj.delete(*keys))
     return 0
 
 
@@ -95,7 +102,7 @@ def get_or_set_cache(
     Returns:
         Cached or computed value
     """
-    cache_obj = cache.get_client(cache_name)
+    cache_obj = _get_cache(cache_name)
     result = cache_obj.get(key)
     if result is not None:
         return result
@@ -130,7 +137,7 @@ def cache_page_conditional(
             if request.method != "GET" or request.GET:
                 return view_func(request, *args, **kwargs)
 
-            cache_obj = cache.get_client(cache_name)
+            cache_obj = _get_cache(cache_name)
             cache_key_str = f"view:{request.path}:{request.GET.urlencode()}"
             cached = cache_obj.get(cache_key_str)
             if cached is not None:

--- a/apps/core/cache_utils.py
+++ b/apps/core/cache_utils.py
@@ -10,14 +10,14 @@ from typing import Any
 from django.core.cache import cache
 
 
-def _get_cache(name: str):
+def _get_cache(name: str) -> Any:
     backend = cache
     if hasattr(cache, "get_client"):
         return cache.get_client(name)
     return backend
 
 
-def cache_key(*args, **kwargs) -> str:
+def cache_key(*args: Any, **kwargs: Any) -> str:
     """Generate a cache key from arguments."""
     key_parts = list(args) + [f"{k}={v}" for k, v in sorted(kwargs.items())]
     key_str = ":".join(str(p) for p in key_parts)
@@ -47,7 +47,7 @@ def cache_result(
 
     def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(*args, **kwargs) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             # Build cache key
             cache_obj = _get_cache(cache_name)
             prefix = key_prefix or func.__name__
@@ -132,7 +132,7 @@ def cache_page_conditional(
 
     def decorator(view_func: Callable) -> Callable:
         @wraps(view_func)
-        def wrapper(request, *args, **kwargs) -> Any:
+        def wrapper(request: Any, *args: Any, **kwargs: Any) -> Any:
             # Only cache GET requests without query params
             if request.method != "GET" or request.GET:
                 return view_func(request, *args, **kwargs)

--- a/apps/core/context_processors.py
+++ b/apps/core/context_processors.py
@@ -1,7 +1,9 @@
 """Site-wide template context."""
 
+from django.http import HttpRequest
+
 from .site_config import get_site_config
 
 
-def site(request):
+def site(request: HttpRequest) -> dict[str, str]:
     return get_site_config()

--- a/apps/core/db_monitoring.py
+++ b/apps/core/db_monitoring.py
@@ -7,17 +7,21 @@ from django.conf import settings
 from django.db import connections
 from django.db.utils import OperationalError, ProgrammingError
 
+# ``cursor`` and ``connection`` are intentionally typed as ``Any`` because the
+# code uses vendor-specific introspection SQL and raw cursor APIs that vary by
+# Django database backend.
+
 logger = logging.getLogger("apps.core.db")
 
 
-def _row_as_dict(cursor) -> dict[str, Any]:
+def _row_as_dict(cursor: Any) -> dict[str, Any]:
     row = cursor.fetchone()
     if row is None:
         return {}
     return {column[0]: value for column, value in zip(cursor.description, row, strict=False)}
 
 
-def _postgres_pool_metrics(connection) -> dict[str, Any]:
+def _postgres_pool_metrics(connection: Any) -> dict[str, Any]:
     with connection.cursor() as cursor:
         cursor.execute(
             """

--- a/apps/core/logging.py
+++ b/apps/core/logging.py
@@ -55,7 +55,7 @@ class RequestLoggingMiddleware:
     def _user_id(request) -> int | None:
         user = getattr(request, "user", None)
         if user is not None and getattr(user, "is_authenticated", False):
-            return user.pk
+            return int(user.pk)
         return None
 
     def __call__(self, request):

--- a/apps/core/logging.py
+++ b/apps/core/logging.py
@@ -4,9 +4,12 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Callable
 from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import Any
+
+from django.http import HttpRequest, HttpResponse
 
 _request_id_context: ContextVar[str | None] = ContextVar("request_id", default=None)
 
@@ -48,20 +51,20 @@ class JsonFormatter(logging.Formatter):
 class RequestLoggingMiddleware:
     _logger = logging.getLogger("apps.request")
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
 
     @staticmethod
-    def _user_id(request) -> int | None:
+    def _user_id(request: HttpRequest) -> int | None:
         user = getattr(request, "user", None)
         if user is not None and getattr(user, "is_authenticated", False):
             return int(user.pk)
         return None
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest) -> HttpResponse:
         started_at = time.monotonic()
         request_id = request.META.get("HTTP_X_REQUEST_ID", "").strip() or str(uuid.uuid4())
-        request.request_id = request_id
+        setattr(request, "request_id", request_id)  # noqa: B010
         token = _request_id_context.set(request_id)
         try:
             response = self.get_response(request)

--- a/apps/core/management/commands/fix_imported_passwords.py
+++ b/apps/core/management/commands/fix_imported_passwords.py
@@ -16,7 +16,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from apps.accounts.models import User
 
@@ -58,11 +58,11 @@ def collect_password_hashes(data: Any) -> dict[str, str]:
 class Command(BaseCommand):
     help = "Fix passwords for users with unusable hashes after Prisma import."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("path", help="Path to Prisma export.json")
         parser.add_argument("--dry-run", action="store_true")
 
-    def handle(self, *args, **opts):
+    def handle(self, *args: Any, **opts: Any) -> None:
         path = Path(opts["path"]).resolve()
         if ".." in path.parts:
             raise CommandError(f"Path traversal is not allowed: {path}")

--- a/apps/core/management/commands/import_prisma_export.py
+++ b/apps/core/management/commands/import_prisma_export.py
@@ -254,7 +254,7 @@ class Command(BaseCommand):
             User.objects.update_or_create(
                 pk=pk,
                 defaults={
-                    "email": d.get("email"),
+                    "email": str(d.get("email") or ""),
                     "first_name": d.get("first_name") or "",
                     "last_name": d.get("last_name") or "",
                     "role": role,

--- a/apps/core/management/commands/import_prisma_export.py
+++ b/apps/core/management/commands/import_prisma_export.py
@@ -18,15 +18,15 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Collection
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from django.contrib.auth.hashers import make_password
 from django.core.management import call_command
-from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.db import models, transaction
 from django.utils.dateparse import parse_datetime
 
 from apps.accounts.models import TokenBlacklist, User
@@ -141,7 +141,7 @@ def normalize_row(row: dict[str, Any], renames: dict[str, str]) -> dict[str, Any
     return out
 
 
-def _concrete_field_map(model) -> dict[str, Any]:
+def _concrete_field_map(model: type[models.Model]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for f in model._meta.get_fields():
         if getattr(f, "concrete", False) and not f.many_to_many:
@@ -151,7 +151,7 @@ def _concrete_field_map(model) -> dict[str, Any]:
     return out
 
 
-def filter_to_fields(model, d: dict[str, Any]) -> dict[str, Any]:
+def filter_to_fields(model: type[models.Model], d: dict[str, Any]) -> dict[str, Any]:
     fields = _concrete_field_map(model)
     out: dict[str, Any] = {}
     for k, v in d.items():
@@ -169,7 +169,7 @@ def filter_to_fields(model, d: dict[str, Any]) -> dict[str, Any]:
 class Command(BaseCommand):
     help = "Import a Prisma JSON export into the Django database."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("path", help="Path to export.json")
         parser.add_argument("--dry-run", action="store_true")
         parser.add_argument(
@@ -178,7 +178,7 @@ class Command(BaseCommand):
             default="",
         )
 
-    def handle(self, *args, **opts):
+    def handle(self, *args: Any, **opts: Any) -> None:
         path = Path(opts["path"]).resolve()
         if ".." in path.parts:
             raise CommandError(f"Path traversal is not allowed: {path}")
@@ -191,7 +191,7 @@ class Command(BaseCommand):
         only = {x.strip() for x in opts["only"].split(",") if x.strip()}
         dry = opts["dry_run"]
 
-        importers: list[tuple[str, Callable[[Iterable[dict]], int]]] = [
+        importers: list[tuple[str, Callable[[Collection[dict[str, Any]]], int]]] = [
             ("User", self._import_users),
             ("Tag", self._import_tags),
             ("Card", self._import_cards),
@@ -234,7 +234,7 @@ class Command(BaseCommand):
 
     # ----- per-model importers -----
 
-    def _import_users(self, rows):
+    def _import_users(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, FK_RENAMES["User"])
             pk = d.pop("id")
@@ -272,7 +272,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_tags(self, rows):
+    def _import_tags(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             Tag.objects.update_or_create(
                 pk=r["id"],
@@ -283,7 +283,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_cards(self, rows):
+    def _import_cards(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, FK_RENAMES["Card"])
             d["updated_date"] = to_dt(d.get("updated_date"))
@@ -298,15 +298,14 @@ class Command(BaseCommand):
             Card.objects.update_or_create(pk=pk, defaults=filter_to_fields(Card, d))
         return len(rows)
 
-    def _import_card_tags(self, rows):
+    def _import_card_tags(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
-            CardTag.objects.get_or_create(
-                card_id=r.get("cardId") or r.get("card_id"),
-                tag_id=r.get("tagId") or r.get("tag_id"),
-            )
+            card_id = cast(int | str, r.get("cardId") or r.get("card_id"))
+            tag_id = cast(int | str, r.get("tagId") or r.get("tag_id"))
+            CardTag.objects.get_or_create(card_id=card_id, tag_id=tag_id)
         return len(rows)
 
-    def _import_card_submissions(self, rows):
+    def _import_card_submissions(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, FK_RENAMES["CardSubmission"])
             d["created_date"] = to_dt(d.get("created_date"))
@@ -317,7 +316,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_card_modifications(self, rows):
+    def _import_card_modifications(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, FK_RENAMES["CardModification"])
             d["created_date"] = to_dt(d.get("created_date"))
@@ -328,7 +327,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_reviews(self, rows):
+    def _import_reviews(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, FK_RENAMES["Review"])
             d["created_date"] = to_dt(d.get("created_date"))
@@ -338,7 +337,7 @@ class Command(BaseCommand):
             Review.objects.update_or_create(pk=pk, defaults=filter_to_fields(Review, d))
         return len(rows)
 
-    def _import_resource_categories(self, rows):
+    def _import_resource_categories(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {})
             pk = d.pop("id")
@@ -347,14 +346,14 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_resource_items(self, rows):
+    def _import_resource_items(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {"categoryId": "category_id"})
             pk = d.pop("id")
             ResourceItem.objects.update_or_create(pk=pk, defaults=filter_to_fields(ResourceItem, d))
         return len(rows)
 
-    def _import_quick_access(self, rows):
+    def _import_quick_access(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {})
             pk = d.pop("id")
@@ -363,7 +362,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_resource_config(self, rows):
+    def _import_resource_config(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {})
             pk = d.pop("id")
@@ -372,7 +371,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_forum_categories(self, rows):
+    def _import_forum_categories(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {"createdBy": "creator_id"})
             pk = d.pop("id")
@@ -381,14 +380,14 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_forum_threads(self, rows):
+    def _import_forum_threads(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {"createdBy": "creator_id", "categoryId": "category_id"})
             pk = d.pop("id")
             ForumThread.objects.update_or_create(pk=pk, defaults=filter_to_fields(ForumThread, d))
         return len(rows)
 
-    def _import_forum_posts(self, rows):
+    def _import_forum_posts(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(
                 r,
@@ -402,7 +401,7 @@ class Command(BaseCommand):
             ForumPost.objects.update_or_create(pk=pk, defaults=filter_to_fields(ForumPost, d))
         return len(rows)
 
-    def _import_help_posts(self, rows):
+    def _import_help_posts(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {"createdBy": "creator_id"})
             pk = d.pop("id")
@@ -411,7 +410,7 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_help_comments(self, rows):
+    def _import_help_comments(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {"createdBy": "creator_id", "postId": "post_id"})
             pk = d.pop("id")
@@ -420,14 +419,14 @@ class Command(BaseCommand):
             )
         return len(rows)
 
-    def _import_indexing(self, rows):
+    def _import_indexing(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {})
             pk = d.pop("id")
             IndexingJob.objects.update_or_create(pk=pk, defaults=filter_to_fields(IndexingJob, d))
         return len(rows)
 
-    def _import_token_blacklist(self, rows):
+    def _import_token_blacklist(self, rows: Collection[dict[str, Any]]) -> int:
         for r in rows:
             d = normalize_row(r, {"userId": "user_id"})
             pk = d.pop("id", None)

--- a/apps/core/management/commands/sync_sequences.py
+++ b/apps/core/management/commands/sync_sequences.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.apps import apps
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandParser
 from django.core.management.color import no_style
 from django.db import DEFAULT_DB_ALIAS, connections, router, transaction
 
@@ -9,14 +11,14 @@ from django.db import DEFAULT_DB_ALIAS, connections, router, transaction
 class Command(BaseCommand):
     help = "Synchronize database sequences with the current maximum primary keys."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--database",
             default=DEFAULT_DB_ALIAS,
             help='Nominates a database to synchronize. Defaults to the "default" database.',
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args: Any, **options: Any) -> None:
         database = options["database"]
         connection = connections[database]
         models = [

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
+from django.http import HttpRequest, HttpResponse
+
 
 class MobileApiCsrfBypassMiddleware:
     """Skip CSRF checks only for requests that use Bearer token authentication.
@@ -8,11 +12,11 @@ class MobileApiCsrfBypassMiddleware:
     authenticate via Authorization header rather than session cookies.
     """
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
 
-    def __call__(self, request):
+    def __call__(self, request: HttpRequest) -> HttpResponse:
         auth_header = request.headers.get("authorization", "")
         if auth_header.startswith("Bearer "):
-            request._dont_enforce_csrf_checks = True
+            setattr(request, "_dont_enforce_csrf_checks", True)  # noqa: B010
         return self.get_response(request)

--- a/apps/core/password_validators.py
+++ b/apps/core/password_validators.py
@@ -1,5 +1,7 @@
 """Custom password validators for enhanced security."""
 
+from typing import Any
+
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
@@ -18,7 +20,7 @@ class PasswordComplexityValidator:
 
     SPECIAL_CHARS = '!@#$%^&*(),.?":{}|<>-_=+'
 
-    def validate(self, password: str, user=None) -> None:
+    def validate(self, password: str, user: Any | None = None) -> None:
         errors = []
 
         if len(password) > 128:

--- a/apps/core/tests.py
+++ b/apps/core/tests.py
@@ -240,7 +240,10 @@ class PrismaImportHelperTests(TestCase):
         self.assertIsNotNone(to_dt("2025-01-01T00:00:00Z"))
         self.assertIsNone(to_dt(None))
         bcrypt_hash = "$2b$12$" + ("a" * 53)
-        self.assertTrue(legacy_password_hash(bcrypt_hash).startswith("bcrypt$"))
+        hashed = legacy_password_hash(bcrypt_hash)
+        self.assertIsNotNone(hashed)
+        assert hashed is not None
+        self.assertTrue(hashed.startswith("bcrypt$"))
 
         by_id, by_email = collect_legacy_password_hashes(
             {"items": [{"id": 10, "email": "U@E.COM", "passwordHash": bcrypt_hash}]}

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,17 +1,17 @@
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import FileResponse, HttpRequest, HttpResponse, JsonResponse
 from django.views.static import serve
 
 from apps.core.db_monitoring import get_database_health
 
 
-def health(_request):
+def health(_request: HttpRequest) -> JsonResponse:
     database = get_database_health()
     status = "ok" if database["healthy"] else "error"
     return JsonResponse({"status": status}, status=200 if database["healthy"] else 503)
 
 
-def media_file(request, path: str):
+def media_file(request: HttpRequest, path: str) -> HttpResponse | FileResponse:
     """Serve user-uploaded media. Only intended for development (DEBUG=True).
 
     In production, configure your reverse proxy or CDN to serve MEDIA_ROOT

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -17,4 +17,4 @@ def media_file(request, path: str):
     In production, configure your reverse proxy or CDN to serve MEDIA_ROOT
     directly and avoid routing media requests through Django.
     """
-    return serve(request, path, document_root=settings.MEDIA_ROOT)
+    return serve(request, path, document_root=str(settings.MEDIA_ROOT))

--- a/apps/directory/forms.py
+++ b/apps/directory/forms.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django import forms
 from django.core.validators import URLValidator
 
@@ -45,7 +47,7 @@ class CardSubmissionForm(forms.ModelForm):
         )
         widgets = {"description": forms.Textarea(attrs={"rows": 5})}
 
-    def clean_image(self):
+    def clean_image(self) -> Any:
         image = self.cleaned_data.get("image")
         if image and image.size > 5 * 1024 * 1024:
             raise forms.ValidationError("Image must be 5 MB or smaller.")
@@ -85,7 +87,7 @@ class CardModificationForm(forms.ModelForm):
         )
         widgets = {"description": forms.Textarea(attrs={"rows": 5})}
 
-    def clean_image(self):
+    def clean_image(self) -> Any:
         image = self.cleaned_data.get("image")
         if image and image.size > 5 * 1024 * 1024:
             raise forms.ValidationError("Image must be 5 MB or smaller.")

--- a/apps/directory/models.py
+++ b/apps/directory/models.py
@@ -51,7 +51,9 @@ class Card(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
     updated_date = models.DateTimeField(auto_now=True)
 
-    tags = models.ManyToManyField(Tag, through="CardTag", related_name="cards")
+    tags: models.ManyToManyField[Tag, CardTag] = models.ManyToManyField(
+        Tag, through="CardTag", related_name="cards"
+    )
 
     class Meta:
         db_table = "cards"

--- a/apps/directory/templatetags/directory_extras.py
+++ b/apps/directory/templatetags/directory_extras.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import re
+from typing import Any
 from urllib.parse import quote_plus
 
 from django import template
+from django.http import HttpRequest
+from django.template.context import Context
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
@@ -9,9 +14,9 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def query_replace(context, **kwargs):
+def query_replace(context: Context, **kwargs: Any) -> str:
     """Render the current request querystring with given keys replaced/removed."""
-    request = context["request"]
+    request: HttpRequest = context["request"]
     params = request.GET.copy()
     for key, value in kwargs.items():
         if value in (None, ""):
@@ -22,7 +27,7 @@ def query_replace(context, **kwargs):
 
 
 @register.filter(name="safe_external_url")
-def safe_external_url(value):
+def safe_external_url(value: Any) -> str:
     """Return the URL only if it uses an allowed scheme; otherwise empty string.
 
     Prevents ``javascript:``/``data:`` URIs from sneaking into ``href`` attributes.
@@ -37,7 +42,7 @@ def safe_external_url(value):
 
 
 @register.filter(name="business_address_url")
-def business_address_url(address, override_url=None):
+def business_address_url(address: Any, override_url: Any | None = None) -> str:
     """Return an override URL or a Google Maps search URL for a physical address."""
     safe_override = safe_external_url(override_url)
     if safe_override:
@@ -48,7 +53,7 @@ def business_address_url(address, override_url=None):
 
 
 @register.filter(name="phone_href")
-def phone_href(value):
+def phone_href(value: Any) -> str:
     """Return a tel: URL using only dialable digits, preserving a leading +."""
     if not value:
         return ""
@@ -61,7 +66,7 @@ def phone_href(value):
 
 
 @register.filter(name="highlight_safe")
-def highlight_safe(value):
+def highlight_safe(value: Any) -> str:
     """Escape an OpenSearch highlight fragment except for the ``<em>`` markers."""
     if value is None:
         return ""

--- a/apps/directory/templatetags/directory_extras.py
+++ b/apps/directory/templatetags/directory_extras.py
@@ -66,7 +66,7 @@ def highlight_safe(value):
     if value is None:
         return ""
     escaped = escape(str(value))
-    escaped = escaped.replace("&lt;em&gt;", "<em>").replace("&lt;/em&gt;", "</em>")
+    highlighted = escaped.replace("&lt;em&gt;", "<em>").replace("&lt;/em&gt;", "</em>")
     return mark_safe(  # nosemgrep: python.django.security.audit.avoid-mark-safe.avoid-mark-safe
-        escaped
+        highlighted
     )

--- a/apps/directory/tests.py
+++ b/apps/directory/tests.py
@@ -67,6 +67,7 @@ class CardSubmissionUploadTests(TestCase):
                 self.assertEqual(response.headers["Location"], reverse("directory:home"))
                 submission = CardSubmission.objects.get(name="Uploaded Business")
                 self.assertEqual(submission.status, CardSubmissionStatus.PENDING)
+                assert submission.image_url is not None
                 self.assertTrue(submission.image_url.startswith("/media/business-submissions/"))
                 saved_path = Path(media_root) / submission.image_url.removeprefix("/media/")
                 self.assertTrue(saved_path.exists())
@@ -94,6 +95,7 @@ class CardSubmissionUploadTests(TestCase):
                 self.assertEqual(response.status_code, 302)
                 submission = CardSubmission.objects.get(name="Served Business")
 
+                assert submission.image_url is not None
                 image_response = self.client.get(submission.image_url)
                 self.assertEqual(image_response.status_code, 200)
                 self.assertEqual(image_response.headers["Content-Type"], "image/png")
@@ -119,6 +121,7 @@ class CardSubmissionUploadTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers["Location"], reverse("cms:submissions_list"))
         submission.refresh_from_db()
+        assert submission.card is not None
         self.assertEqual(submission.card.image_url, "/media/business-submissions/example.png")
 
 
@@ -488,6 +491,7 @@ class DirectoryViewTests(TestCase):
 
                 self.assertEqual(response.status_code, 201)
                 submission = CardSubmission.objects.get(name="Mobile Upload")
+                assert submission.image_url is not None
                 self.assertTrue(submission.image_url.startswith("/media/business-submissions/"))
                 saved_path = Path(media_root) / submission.image_url.removeprefix("/media/")
                 self.assertTrue(saved_path.exists())

--- a/apps/directory/views.py
+++ b/apps/directory/views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 from django.conf import settings
@@ -36,7 +37,7 @@ def _split_tags(text: str) -> list[str]:
     return [t.strip() for t in (text or "").replace(";", ",").split(",") if t.strip()]
 
 
-def _absolute_url(request: HttpRequest, view_name: str, **kwargs) -> str:
+def _absolute_url(request: HttpRequest, view_name: str, **kwargs: Any) -> str:
     return request.build_absolute_uri(reverse(view_name, kwargs=kwargs))
 
 
@@ -80,7 +81,7 @@ def _form_payload(payload: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _serialize_user(user) -> dict[str, object] | None:
+def _serialize_user(user: Any) -> dict[str, object] | None:
     if user is None:
         return None
     return {
@@ -678,7 +679,7 @@ _ALLOWED_IMAGE_TYPES = {
 }
 
 
-def _save_business_image(image) -> str:
+def _save_business_image(image: Any) -> str:
     suffix = Path(image.name).suffix.lower()
     allowed = suffix in _ALLOWED_IMAGE_TYPES
     content_type = getattr(image, "content_type", "")

--- a/apps/directory/views.py
+++ b/apps/directory/views.py
@@ -50,7 +50,7 @@ def _request_payload(request: HttpRequest) -> dict[str, object]:
         if not isinstance(payload, dict):
             raise ValueError("Request body must be a JSON object.")
         return payload
-    return request.POST.dict()
+    return dict(request.POST)
 
 
 def _payload_text(payload: dict[str, object], *keys: str) -> str:
@@ -64,7 +64,7 @@ def _payload_text(payload: dict[str, object], *keys: str) -> str:
     return ""
 
 
-def _form_payload(payload: dict[str, object]) -> dict[str, str]:
+def _form_payload(payload: dict[str, object]) -> dict[str, object]:
     return {
         "name": _payload_text(payload, "name"),
         "description": _payload_text(payload, "description"),
@@ -197,9 +197,9 @@ def home(request: HttpRequest) -> HttpResponse:
         tags = Tag.objects.annotate(used=Count("cards")).filter(used__gt=0).order_by("name")
     except OperationalError:
         messages.error(request, "The directory is temporarily unavailable. Please try again.")
-        paginator = Paginator(Card.objects.none(), settings.PAGINATION_DEFAULT_LIMIT)
+        paginator = Paginator(Card.objects.none(), settings.PAGINATION_DEFAULT_LIMIT)  # type: ignore[arg-type]
         page = paginator.get_page(1)
-        tags = Tag.objects.none()
+        tags = Tag.objects.none()  # type: ignore[assignment]
 
     ctx = {
         "page_obj": page,
@@ -375,6 +375,7 @@ def _safe_int(value: str | None, *, default: int, minimum: int, maximum: int) ->
 def api_submissions(request: HttpRequest) -> HttpResponse:
     if not request.user.is_authenticated:
         return _api_auth_failure()
+    assert request.user.is_authenticated
 
     if request.method == "GET":
         submissions = [
@@ -390,7 +391,10 @@ def api_submissions(request: HttpRequest) -> HttpResponse:
             .order_by("-created_date")
         ]
         items = submissions + modifications
-        items.sort(key=lambda item: item["created_date"], reverse=True)
+        from datetime import datetime
+        from typing import cast
+
+        items.sort(key=lambda item: cast(datetime, item["created_date"]), reverse=True)
         return JsonResponse(items, safe=False)
 
     payload = _request_payload(request)
@@ -439,6 +443,7 @@ def api_submissions(request: HttpRequest) -> HttpResponse:
 def api_suggest_edit(request: HttpRequest, pk: int) -> HttpResponse:
     if not request.user.is_authenticated:
         return _api_auth_failure()
+    assert request.user.is_authenticated
 
     card = get_object_or_404(Card, pk=pk, approved=True)
     payload = _request_payload(request)
@@ -519,6 +524,7 @@ def card_detail(request: HttpRequest, pk: int, slug: str | None = None) -> HttpR
 @login_required
 @require_http_methods(["POST"])
 def submit_review(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     card = get_object_or_404(Card, pk=pk, approved=True)
     if Review.objects.filter(card=card, user=request.user).exists():
         messages.error(request, "You have already reviewed this business.")
@@ -561,6 +567,7 @@ def submit_review(request: HttpRequest, pk: int) -> HttpResponse:
 @login_required
 @require_http_methods(["GET", "POST"])
 def card_submit(request: HttpRequest) -> HttpResponse:
+    assert request.user.is_authenticated
     if request.method == "POST":
         form = CardSubmissionForm(request.POST, request.FILES)
         if form.is_valid():
@@ -599,6 +606,7 @@ def card_submit(request: HttpRequest) -> HttpResponse:
 @login_required
 @require_http_methods(["GET", "POST"])
 def card_update_submit(request: HttpRequest, pk: int) -> HttpResponse:
+    assert request.user.is_authenticated
     card = get_object_or_404(Card, pk=pk, approved=True)
     if request.method == "POST":
         form = CardModificationForm(request.POST, request.FILES)
@@ -685,6 +693,7 @@ def _save_business_image(image) -> str:
 def my_submissions(request: HttpRequest) -> HttpResponse:
     if not request.user.is_authenticated:
         return redirect("accounts:login")
+    assert request.user.is_authenticated
     subs = CardSubmission.objects.filter(submitter=request.user).order_by("-created_date")
     modifications = (
         CardModification.objects.filter(submitter=request.user)

--- a/apps/directory/views.py
+++ b/apps/directory/views.py
@@ -50,7 +50,7 @@ def _request_payload(request: HttpRequest) -> dict[str, object]:
         if not isinstance(payload, dict):
             raise ValueError("Request body must be a JSON object.")
         return payload
-    return dict(request.POST)
+    return request.POST.dict()  # type: ignore[return-value]
 
 
 def _payload_text(payload: dict[str, object], *keys: str) -> str:

--- a/apps/events/forms.py
+++ b/apps/events/forms.py
@@ -30,7 +30,7 @@ class EventSubmissionForm(forms.ModelForm):
         widgets = {"description": forms.Textarea(attrs={"rows": 5})}
 
     def clean(self):
-        cleaned = super().clean()
+        cleaned = super().clean() or {}
         start_at = cleaned.get("start_at")
         end_at = cleaned.get("end_at")
         if start_at and end_at and end_at < start_at:

--- a/apps/events/forms.py
+++ b/apps/events/forms.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django import forms
 from django.core.validators import URLValidator
 
@@ -29,7 +31,7 @@ class EventSubmissionForm(forms.ModelForm):
         fields = ("title", "description", "location", "start_at", "end_at", "url", "all_day")
         widgets = {"description": forms.Textarea(attrs={"rows": 5})}
 
-    def clean(self):
+    def clean(self) -> dict[str, Any]:
         cleaned = super().clean() or {}
         start_at = cleaned.get("start_at")
         end_at = cleaned.get("end_at")

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import calendar as pycalendar
 from datetime import UTC, date, datetime, timedelta
+from typing import Any
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -21,7 +22,7 @@ from .forms import EventSubmissionForm
 from .models import Event, EventStatus, EventSubmission
 
 
-def _absolute_url(request: HttpRequest, view_name: str, **kwargs) -> str:
+def _absolute_url(request: HttpRequest, view_name: str, **kwargs: Any) -> str:
     return request.build_absolute_uri(reverse(view_name, kwargs=kwargs))
 
 
@@ -84,7 +85,7 @@ def _event_dates(event: Event) -> list[date]:
     return days
 
 
-def _approved_events_queryset():
+def _approved_events_queryset() -> QuerySet[Event]:
     return Event.objects.filter(approved=True).order_by("start_at", "title")
 
 

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -33,7 +33,7 @@ FUZZY_SEARCH_FIELDS = [
 try:
     from opensearchpy import OpenSearch
 except ImportError:  # pragma: no cover
-    OpenSearch = None
+    OpenSearch = None  # type: ignore[misc,assignment]
 
 
 def _client():
@@ -146,9 +146,9 @@ def _response_total(response: dict) -> int:
     resource_count = response.get("aggregations", {}).get("resource_count", {}).get("value")
     if isinstance(resource_count, int | float):
         return int(resource_count)
-    hits = response.get("hits", {})
-    total_obj = hits.get("total", 0)
-    return total_obj.get("value", 0) if isinstance(total_obj, dict) else total_obj
+    hits: dict = response.get("hits", {})
+    total_obj: dict | int = hits.get("total", 0)
+    return int(total_obj.get("value", 0)) if isinstance(total_obj, dict) else int(total_obj)
 
 
 def _parse_hit(hit: dict, *, excerpt_length: int) -> dict:

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -36,7 +36,7 @@ except ImportError:  # pragma: no cover
     OpenSearch = None  # type: ignore[misc,assignment]
 
 
-def _client():
+def _client() -> OpenSearch | None:
     if OpenSearch is None:
         return None
     scheme = "https" if settings.OPENSEARCH_USE_HTTPS else "http"
@@ -170,7 +170,7 @@ def _parse_hit(hit: dict, *, excerpt_length: int) -> dict:
 
 
 def _search_results(
-    client,
+    client: OpenSearch,
     query: str,
     page_num: int,
     page_size: int,

--- a/apps/webhooks/management/commands/send_admin_digest.py
+++ b/apps/webhooks/management/commands/send_admin_digest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
@@ -17,7 +18,7 @@ from apps.webhooks.service import dispatch_event
 class Command(BaseCommand):
     help = "Send daily admin digest to configured webhook endpoints."
 
-    def handle(self, *args, **options):
+    def handle(self, *args: Any, **options: Any) -> None:
         if os.getenv("WEBHOOKS_ENABLED", "false").lower() not in {"1", "true", "yes", "on"}:
             self.stdout.write(
                 self.style.WARNING("WEBHOOKS_ENABLED is false; skipping webhook digest.")

--- a/apps/webhooks/service.py
+++ b/apps/webhooks/service.py
@@ -53,7 +53,8 @@ def _is_safe_webhook_url(url: str) -> bool:
     try:
         # Resolve hostname to check for internal IPs.
         resolved = socket.getaddrinfo(hostname, None)[0][4][0]
-        if any(resolved.startswith(net) for net in _BLOCKED_NETWORKS):
+        resolved_str = str(resolved)
+        if any(resolved_str.startswith(net) for net in _BLOCKED_NETWORKS):
             return False
     except socket.gaierror:
         pass
@@ -83,7 +84,7 @@ def _delivery_max_retries(endpoint: WebhookEndpoint) -> int:
     if isinstance(policy, dict):
         raw = policy.get("max_retries", policy.get("maxRetries", DEFAULT_MAX_RETRIES))
         try:
-            return max(0, int(raw))
+            return max(0, int(str(raw) if raw is not None else DEFAULT_MAX_RETRIES))
         except (TypeError, ValueError):
             return DEFAULT_MAX_RETRIES
     return DEFAULT_MAX_RETRIES
@@ -183,7 +184,7 @@ def dispatch_event(
         type=event_type,
         data=json.dumps(data),
         timestamp=timezone.now(),
-        environment=environment or os.getenv("DEPLOY_ENV", "production"),
+        environment=str(environment or os.getenv("DEPLOY_ENV", "production")),
         source_info=source_info,
     )
 

--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -8,6 +8,8 @@ This version works without the Flask backend by:
 - Using direct Postgres connection for progress tracking (optional)
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
 import os
@@ -15,6 +17,7 @@ import time
 from collections import deque
 from datetime import UTC, datetime
 from hashlib import sha256
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urldefrag, urljoin, urlparse, urlunparse
 from urllib.robotparser import RobotFileParser
 
@@ -33,20 +36,23 @@ except ImportError:
 
 from config import IndexerConfig
 
+if TYPE_CHECKING:
+    from psycopg import Connection
+
 # Set up logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
 class ResourceIndexer:
-    def __init__(self, use_tracking=True):
+    def __init__(self, use_tracking: bool = True) -> None:
         self.opensearch_host = os.getenv("OPENSEARCH_HOST", "opensearch-service")
         self.opensearch_port = int(os.getenv("OPENSEARCH_PORT", "9200"))
         self.opensearch_use_https = os.getenv("OPENSEARCH_USE_HTTPS", "false").lower() == "true"
         self.namespace = os.getenv("NAMESPACE", "default")
         opensearch_username = os.getenv("OPENSEARCH_USERNAME", "")
         opensearch_password = os.getenv("OPENSEARCH_PASSWORD", "")
-        http_auth = None
+        http_auth: tuple[str, str] | None = None
         if opensearch_username:
             http_auth = (opensearch_username, opensearch_password)
 
@@ -77,14 +83,14 @@ class ResourceIndexer:
         self.index_name = f"{self.namespace}-resources"
 
         # Cache for robots.txt parsers to avoid repeated fetches
-        self.robots_cache = {}
+        self.robots_cache: dict[str, RobotFileParser] = {}
 
         # User agent for robots.txt compliance
         self.user_agent = IndexerConfig.USER_AGENT
 
         # Initialize database connection for tracking (optional)
         self.use_tracking = use_tracking and HAS_PSYCOPG
-        self.db_conn = None
+        self.db_conn: Connection[Any] | None = None
         if self.use_tracking:
             try:
                 db_url = self._build_database_url()
@@ -94,7 +100,7 @@ class ResourceIndexer:
                 logger.warning(f"Could not connect to database for tracking: {e}")
                 self.use_tracking = False
 
-    def _build_database_url(self):
+    def _build_database_url(self) -> str:
         """Build database URL from environment variables"""
         database_url = os.getenv("DATABASE_URL")
         if database_url:
@@ -109,7 +115,7 @@ class ResourceIndexer:
         return f"postgresql://{user}:{password}@{host}:{port}/{database}"
 
     @staticmethod
-    def _index_properties():
+    def _index_properties() -> dict[str, dict[str, str]]:
         return {
             "resource_id": {"type": "integer"},
             "business_name": {"type": "text"},
@@ -130,7 +136,7 @@ class ResourceIndexer:
             "indexed_at": {"type": "date"},
         }
 
-    def get_robots_parser(self, base_domain):
+    def get_robots_parser(self, base_domain: str) -> RobotFileParser:
         """Get or create a robots.txt parser for the given domain"""
         if base_domain in self.robots_cache:
             return self.robots_cache[base_domain]
@@ -154,7 +160,7 @@ class ResourceIndexer:
             self.robots_cache[base_domain] = rp
             return rp
 
-    def is_url_allowed(self, url):
+    def is_url_allowed(self, url: str) -> bool:
         """Check if URL is allowed by robots.txt"""
         try:
             parsed_url = urlparse(url)
@@ -167,7 +173,7 @@ class ResourceIndexer:
             # If we can't check, be conservative and allow it
             return True
 
-    def _normalize_page_url(self, url):
+    def _normalize_page_url(self, url: str | None) -> str:
         """Normalize URLs for crawl deduplication and result links."""
         if not url:
             return ""
@@ -182,12 +188,15 @@ class ResourceIndexer:
         )
         return urlunparse(normalized)
 
-    def _extract_internal_links(self, soup, current_url, site_netloc):
+    def _extract_internal_links(
+        self, soup: BeautifulSoup, current_url: str, site_netloc: str
+    ) -> list[str]:
         """Extract same-site HTTP links from a page."""
-        links = []
-        seen = set()
+        links: list[str] = []
+        seen: set[str] = set()
         for anchor in soup.find_all("a", href=True):
-            candidate = self._normalize_page_url(urljoin(current_url, anchor["href"]))
+            href = cast(str, anchor["href"])
+            candidate = self._normalize_page_url(urljoin(current_url, href))
             if not candidate:
                 continue
             parsed = urlparse(candidate)
@@ -215,7 +224,7 @@ class ResourceIndexer:
             links.append(candidate)
         return links
 
-    def fetch_cards(self):
+    def fetch_cards(self) -> list[dict[str, Any]]:
         """Fetch business cards from the Next.js API"""
         try:
             # Fetch all cards from the API
@@ -234,7 +243,7 @@ class ResourceIndexer:
             response.raise_for_status()
 
             data = response.json()
-            cards = data.get("cards", [])
+            cards: list[dict[str, Any]] = data.get("cards", [])
 
             logger.info(f"Fetched {len(cards)} cards from API")
             return cards
@@ -242,7 +251,7 @@ class ResourceIndexer:
             logger.error(f"Error fetching cards from API: {e}")
             return []
 
-    def scrape_page_content(self, url, max_retries=3):
+    def scrape_page_content(self, url: str, max_retries: int = 3) -> dict[str, Any]:
         """Scrape content from a webpage with retries"""
         normalized_url = self._normalize_page_url(url) or url
         if not self.is_url_allowed(url):
@@ -322,18 +331,18 @@ class ResourceIndexer:
             "links": [],
         }
 
-    def scrape_site_pages(self, start_url):
+    def scrape_site_pages(self, start_url: str) -> list[dict[str, Any]]:
         """Crawl and scrape the homepage plus same-site pages."""
         start_url = self._normalize_page_url(start_url)
         if not start_url:
             return []
 
         site_netloc = urlparse(start_url).netloc
-        queue = deque([start_url])
-        queued = {start_url}
-        crawled = set()
-        indexed_pages = set()
-        pages: list[dict[str, object]] = []
+        queue: deque[str] = deque([start_url])
+        queued: set[str] = {start_url}
+        crawled: set[str] = set()
+        indexed_pages: set[str] = set()
+        pages: list[dict[str, Any]] = []
 
         while queue and len(pages) < IndexerConfig.MAX_PAGES_PER_SITE:
             current_url = queue.popleft()
@@ -368,7 +377,7 @@ class ResourceIndexer:
 
         return pages
 
-    def index_resource(self, card):
+    def index_resource(self, card: dict[str, Any]) -> None:
         """Index a single business card into OpenSearch"""
         try:
             card_id = card["id"]
@@ -436,7 +445,7 @@ class ResourceIndexer:
         except Exception as e:
             logger.error(f"Error indexing card {card.get('id', 'unknown')}: {e}")
 
-    def create_index(self):
+    def create_index(self) -> None:
         """Create the OpenSearch index if it doesn't exist"""
         properties = self._index_properties()
         if self.client.indices.exists(index=self.index_name):
@@ -457,7 +466,7 @@ class ResourceIndexer:
         self.client.indices.create(index=self.index_name, body=index_body)
         logger.info(f"Created index {self.index_name}")
 
-    def run(self, reindex_all=False):
+    def run(self, reindex_all: bool = False) -> None:
         """Run the indexer"""
         logger.info("Starting indexer...")
 
@@ -482,13 +491,13 @@ class ResourceIndexer:
 
         logger.info(f"Indexing complete. Processed {total} cards")
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """Cleanup resources"""
         if self.db_conn:
             self.db_conn.close()
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Index business cards into OpenSearch")
     parser.add_argument(
         "--reindex-all",

--- a/indexer/indexer.py
+++ b/indexer/indexer.py
@@ -278,7 +278,7 @@ class ResourceIndexer:
                 page_description = ""
                 meta_desc = soup.find("meta", attrs={"name": "description"})
                 if meta_desc:
-                    page_description = meta_desc.get("content", "").strip()
+                    page_description = str(meta_desc.get("content", "") or "").strip()
 
                 # Remove script and style elements
                 for script in soup(["script", "style"]):
@@ -333,7 +333,7 @@ class ResourceIndexer:
         queued = {start_url}
         crawled = set()
         indexed_pages = set()
-        pages = []
+        pages: list[dict[str, object]] = []
 
         while queue and len(pages) < IndexerConfig.MAX_PAGES_PER_SITE:
             current_url = queue.popleft()

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,7 +37,7 @@ version = "3.11.1"
 description = "ASGI specs, helper code, and adapters"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"},
     {file = "asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce"},
@@ -45,6 +45,49 @@ files = [
 
 [package.extras]
 tests = ["mypy (>=1.14.0)", "pytest", "pytest-asyncio"]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+description = "Python bindings for mypy AST serialization"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c"},
+    {file = "ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590"},
+    {file = "ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642"},
+    {file = "ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6"},
+]
 
 [[package]]
 name = "attrs"
@@ -708,7 +751,7 @@ version = "6.0.5"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.12"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0"},
     {file = "django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269"},
@@ -758,6 +801,46 @@ redis = ">=4.0.2"
 
 [package.extras]
 hiredis = ["redis[hiredis] (>=4.0.2)"]
+
+[[package]]
+name = "django-stubs"
+version = "6.0.5"
+description = "Mypy stubs for Django"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "django_stubs-6.0.5-py3-none-any.whl", hash = "sha256:9fb9eede9b2fc47b36c3dc4a93652eb959dff45466ec4a580e4a22782192d746"},
+    {file = "django_stubs-6.0.5.tar.gz", hash = "sha256:7742b8e60afc68a8545158e2bdb103376d5a092f7902c17f370920a9c08eb957"},
+]
+
+[package.dependencies]
+django = "*"
+django-stubs-ext = ">=6.0.2"
+mypy = {version = ">=1.13,<2.2", optional = true, markers = "extra == \"compatible-mypy\""}
+types-pyyaml = "*"
+typing-extensions = ">=4.11.0"
+
+[package.extras]
+compatible-mypy = ["mypy (>=1.13,<2.2)"]
+oracle = ["oracledb"]
+redis = ["redis", "types-redis"]
+
+[[package]]
+name = "django-stubs-ext"
+version = "6.0.5"
+description = "Monkey-patching and extensions for django-stubs"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "django_stubs_ext-6.0.5-py3-none-any.whl", hash = "sha256:a9932c8233d6dd4e34ae0b192026379c1a9be8f0b7c27aa1fa09ae215169773e"},
+    {file = "django_stubs_ext-6.0.5.tar.gz", hash = "sha256:1cc325e991303849bce70e19748981b225ef08b37256f263e113caf97cd3bcc0"},
+]
+
+[package.dependencies]
+django = "*"
+typing-extensions = "*"
 
 [[package]]
 name = "djangorestframework"
@@ -1177,6 +1260,107 @@ files = [
 referencing = ">=0.31.0"
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+description = "Mypyc runtime library"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f"},
+    {file = "librt-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ae627397a2f351560440d872d6f7c8dbb4072e57868e7b2fc5b8b430fe489d45"},
+    {file = "librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c"},
+    {file = "librt-0.11.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:7e82e642ab0f7608ce2fe53d76ca2280a9ee33a1b06556142c7c6fe80a86fc33"},
+    {file = "librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884"},
+    {file = "librt-0.11.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d36a51b3d93320b686588e27123f4995804dbf1bce81df78c02fc3c6eea9280"},
+    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d00f3ac06a2a8b246327f11e186a53a100a4d5c7ed52346367e5ec751d51586c"},
+    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:461bbceede621f1ffb8839755f8663e886087ee7af16294cab7fb4d782c62eeb"},
+    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0cad8a4d6a8ff03c9b76f9414caccd78e7cfbc8a2e12fa334d8e1d9932753783"},
+    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f37aa505b3cf60701562eddb32df74b12a9e380c207fd8b06dd157a943ac7ea0"},
+    {file = "librt-0.11.0-cp310-cp310-win32.whl", hash = "sha256:94663a21534637f0e787ec2a2a756022df6e5b7b2335a5cdd7d8e33d68a2af89"},
+    {file = "librt-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:dec7db73758c2b54953fd8b7fe348c45188fe26b39ee18446196edd08453a5d4"},
+    {file = "librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29"},
+    {file = "librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9"},
+    {file = "librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5"},
+    {file = "librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b"},
+    {file = "librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89"},
+    {file = "librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc"},
+    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5"},
+    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7"},
+    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d"},
+    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412"},
+    {file = "librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d"},
+    {file = "librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73"},
+    {file = "librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c"},
+    {file = "librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46"},
+    {file = "librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3"},
+    {file = "librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67"},
+    {file = "librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a"},
+    {file = "librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a"},
+    {file = "librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f"},
+    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b"},
+    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766"},
+    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d"},
+    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8"},
+    {file = "librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a"},
+    {file = "librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9"},
+    {file = "librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c"},
+    {file = "librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894"},
+    {file = "librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c"},
+    {file = "librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea"},
+    {file = "librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230"},
+    {file = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"},
+    {file = "librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3"},
+    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21"},
+    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930"},
+    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be"},
+    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e"},
+    {file = "librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e"},
+    {file = "librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47"},
+    {file = "librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44"},
+    {file = "librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd"},
+    {file = "librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4"},
+    {file = "librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8"},
+    {file = "librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b"},
+    {file = "librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175"},
+    {file = "librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03"},
+    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c"},
+    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3"},
+    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96"},
+    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe"},
+    {file = "librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f"},
+    {file = "librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7"},
+    {file = "librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1"},
+    {file = "librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72"},
+    {file = "librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa"},
+    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548"},
+    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2"},
+    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f"},
+    {file = "librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51"},
+    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2"},
+    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085"},
+    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3"},
+    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd"},
+    {file = "librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8"},
+    {file = "librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c"},
+    {file = "librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253"},
+    {file = "librt-0.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6bd72d903911d995ab666dbd1871f8b1e80925a699af8063fbf50053329fb05f"},
+    {file = "librt-0.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ef69ac715f3cd8e5cd252cb2aebfa72c015492aacc339d5d7bf8fef3c62c677"},
+    {file = "librt-0.11.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:624a40c4a4ad7773315c287276cd024509b2c66ff5904f504bfc08d2c70293ab"},
+    {file = "librt-0.11.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:41dc19fe150b69716c8ece4f76773a9e8813fe3e35e032a58b4d46423fb8d7c0"},
+    {file = "librt-0.11.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4e8bd98ea9c47ae90b319a087ab28dac493f1ffbc1ecd1f28fcdbf3b7e1108d1"},
+    {file = "librt-0.11.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84308fc49423ce6475d1c5d1985cd69a8ca9f0325fc7d5f81bb690a3f3625d4e"},
+    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ff0fbaf5f44a21beeb0110f2ab64f45135a9536a834b79c0d1ef018f2786bbfa"},
+    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9c028a9442a18e266955d364ce42259136e79a7ba14d773e0d778d5f70cd56f1"},
+    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:9f1692105a02bcf853f355032a5fdc5494358ef83d8fd22d16de375c85cec3f5"},
+    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7a80a71e1fda83cc752a9141e87aae7fef279538597564d670e9ce513f286192"},
+    {file = "librt-0.11.0-cp39-cp39-win32.whl", hash = "sha256:140695816ddf3c86eb972981a26f35efd871c44b0c3aed44c8cd01749386617f"},
+    {file = "librt-0.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:92f7ff819c197fc30473190a12c2856f325ac90aabfccbeb2072d28cc2e234e3"},
+    {file = "librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1243,6 +1427,89 @@ groups = ["dev"]
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a6beb180257a805961aea9ec591bbd0bd17f1e18d35b8456d57aee5bedfedc"},
+    {file = "mypy-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ef78c1d306bbf9a8a12f526c44902c9c28dffd6c52c52bf6a72641ce18d3849"},
+    {file = "mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c209a90853081ff01d01ee895cafe10f7db1474e0d95beaeef0f6c1db9119bbd"},
+    {file = "mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47cebf61abde7c088a4e27718a8b13a81655686b2e9c251f5c0915a802248166"},
+    {file = "mypy-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d57a90ae5e872138a425ec328edbc9b235d1934c4377881a33ec05b341acc9a8"},
+    {file = "mypy-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:aea7f7a8a55b459c34275fc468ada6ca7c173a5e43a68f5dbe588a563d8a06b8"},
+    {file = "mypy-2.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:c989640253f0d76843e9c6c1bbf4bd48c5e85ada61bde4beb37cb3eca035685e"},
+    {file = "mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41"},
+    {file = "mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca"},
+    {file = "mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538"},
+    {file = "mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398"},
+    {file = "mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563"},
+    {file = "mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389"},
+    {file = "mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666"},
+    {file = "mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af"},
+    {file = "mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6"},
+    {file = "mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211"},
+    {file = "mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b"},
+    {file = "mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22"},
+    {file = "mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b"},
+    {file = "mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8"},
+    {file = "mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5"},
+    {file = "mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e"},
+    {file = "mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e"},
+    {file = "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"},
+    {file = "mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5"},
+    {file = "mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65"},
+    {file = "mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d"},
+    {file = "mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2"},
+    {file = "mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f"},
+    {file = "mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4"},
+    {file = "mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef"},
+    {file = "mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135"},
+    {file = "mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21"},
+    {file = "mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57"},
+    {file = "mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e"},
+    {file = "mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780"},
+    {file = "mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd"},
+    {file = "mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08"},
+    {file = "mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081"},
+    {file = "mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7"},
+    {file = "mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6"},
+    {file = "mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289"},
+    {file = "mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633"},
+]
+
+[package.dependencies]
+ast-serialize = ">=0.3.0,<1.0.0"
+librt = {version = ">=0.11.0", markers = "platform_python_implementation != \"PyPy\""}
+mypy_extensions = ">=1.0.0"
+pathspec = ">=1.0.0"
+typing_extensions = [
+    {version = ">=4.6.0", markers = "python_version < \"3.15\""},
+    {version = ">=4.14.0", markers = "python_version >= \"3.15\""},
+]
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+faster-cache = ["orjson"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
@@ -1477,6 +1744,23 @@ files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
+    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
+]
+
+[package.extras]
+hyperscan = ["hyperscan (>=0.7)"]
+optional = ["typing-extensions (>=4)"]
+re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "peewee"
@@ -2651,7 +2935,7 @@ version = "0.5.5"
 description = "A non-validating SQL parser."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba"},
     {file = "sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e"},
@@ -2761,6 +3045,18 @@ files = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd"},
+    {file = "types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -2793,7 +3089,7 @@ version = "2026.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
@@ -3012,4 +3308,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "611249d8eda63f26182b321aef50a9b6fec46e9791504772a700f91c265e1d9b"
+content-hash = "44e19555e54a0b4bfbe0d2b22c3d8df0713998f21175cdbd193fd0a477a7454b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,14 +14,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
-    {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
+    {file = "anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9"},
+    {file = "anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89"},
 ]
 
 [package.dependencies]
@@ -180,14 +180,14 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.15.0"
 description = "Screen-scraping library"
 optional = false
 python-versions = ">=3.7.0"
 groups = ["main"]
 files = [
-    {file = "beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"},
-    {file = "beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"},
+    {file = "beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"},
+    {file = "beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7"},
 ]
 
 [package.dependencies]
@@ -227,14 +227,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
-    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
+    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
 
 [[package]]
@@ -655,61 +655,58 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "49.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["dev"]
 files = [
-    {file = "cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5"},
-    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321"},
-    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74"},
-    {file = "cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4"},
-    {file = "cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7"},
-    {file = "cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057"},
-    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae"},
-    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c"},
-    {file = "cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f"},
-    {file = "cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12"},
-    {file = "cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239"},
-    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c"},
-    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4"},
-    {file = "cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd"},
-    {file = "cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a"},
-    {file = "cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"},
+    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
+    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
+    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
+    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
+    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
+    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
+    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
 ]
 
 [package.dependencies]
@@ -720,14 +717,14 @@ ssh = ["bcrypt (>=3.1.5)"]
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.3"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
 groups = ["dev"]
 files = [
-    {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
-    {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
+    {file = "distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"},
+    {file = "distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"},
 ]
 
 [[package]]
@@ -747,14 +744,14 @@ django = ">=4.2"
 
 [[package]]
 name = "django"
-version = "6.0.5"
+version = "6.0.6"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.12"
 groups = ["main", "dev"]
 files = [
-    {file = "django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0"},
-    {file = "django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269"},
+    {file = "django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2"},
+    {file = "django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713"},
 ]
 
 [package.dependencies]
@@ -768,14 +765,14 @@ bcrypt = ["bcrypt (>=4.1.1)"]
 
 [[package]]
 name = "django-environ"
-version = "0.13.0"
+version = "0.14.0"
 description = "A package that allows you to utilize 12factor inspired environment variables to configure your Django application."
 optional = false
 python-versions = "<4,>=3.9"
 groups = ["main"]
 files = [
-    {file = "django_environ-0.13.0-py3-none-any.whl", hash = "sha256:37799d14cd78222c6fd8298e48bfe17965ff8e586091ad66a463e52e0e7b799e"},
-    {file = "django_environ-0.13.0.tar.gz", hash = "sha256:6c401e4c219442c2c4588c2116d5292b5484a6f69163ed09cd41f3943bfb645f"},
+    {file = "django_environ-0.14.0-py3-none-any.whl", hash = "sha256:8dbe8a57f0a540ab8abd6f54f230de5e99e3a2c9d797cb9caecb037bca3d47d8"},
+    {file = "django_environ-0.14.0.tar.gz", hash = "sha256:b6c48d93b9d2ff8a3ea14099e90c35aa4f101c1b4d5f262dfee0d27b06742ed7"},
 ]
 
 [package.extras]
@@ -909,14 +906,14 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "face"
-version = "26.0.0"
+version = "26.0.1"
 description = "A command-line application framework (and CLI parser). Friendly for users, full-featured for developers."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "face-26.0.0-py3-none-any.whl", hash = "sha256:6ec9cf271d8ee2447f04b14264209a09ec9cbe8252255e61fb7ab6b154e300f9"},
-    {file = "face-26.0.0.tar.gz", hash = "sha256:ae12136ff0052f124811f5319670a8d9d29b7d2caaaabe542813690967cc6bca"},
+    {file = "face-26.0.1-py3-none-any.whl", hash = "sha256:ab0a83c37c9789dce658a67a9a80eafaa113c9ec37c5a9d950ff5480542a062d"},
+    {file = "face-26.0.1.tar.gz", hash = "sha256:8183d94bc248baaea855a9f8445f97a22a9988908e60abddccc6e251da77c4c6"},
 ]
 
 [package.dependencies]
@@ -924,14 +921,14 @@ boltons = ">=20.0.0"
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
-    {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
+    {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
+    {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
 ]
 
 [[package]]
@@ -975,80 +972,70 @@ grpc = ["grpcio (>=1.44.0,<2.0.0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.80.0"
+version = "1.81.1"
 description = "HTTP/2-based RPC framework"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "grpcio-1.80.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:886457a7768e408cdce226ad1ca67d2958917d306523a0e21e1a2fdaa75c9c9c"},
-    {file = "grpcio-1.80.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7b641fc3f1dc647bfd80bd713addc68f6d145956f64677e56d9ebafc0bd72388"},
-    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33eb763f18f006dc7fee1e69831d38d23f5eccd15b2e0f92a13ee1d9242e5e02"},
-    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:52d143637e3872633fc7dd7c3c6a1c84e396b359f3a72e215f8bf69fd82084fc"},
-    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c51bf8ac4575af2e0678bccfb07e47321fc7acb5049b4482832c5c195e04e13a"},
-    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:50a9871536d71c4fba24ee856abc03a87764570f0c457dd8db0b4018f379fed9"},
-    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a72d84ad0514db063e21887fbacd1fd7acb4d494a564cae22227cd45c7fbf199"},
-    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f7691a6788ad9196872f95716df5bc643ebba13c97140b7a5ee5c8e75d1dea81"},
-    {file = "grpcio-1.80.0-cp310-cp310-win32.whl", hash = "sha256:46c2390b59d67f84e882694d489f5b45707c657832d7934859ceb8c33f467069"},
-    {file = "grpcio-1.80.0-cp310-cp310-win_amd64.whl", hash = "sha256:dc053420fc75749c961e2a4c906398d7c15725d36ccc04ae6d16093167223b58"},
-    {file = "grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a"},
-    {file = "grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060"},
-    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2"},
-    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21"},
-    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab"},
-    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1"},
-    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106"},
-    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6"},
-    {file = "grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440"},
-    {file = "grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9"},
-    {file = "grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0"},
-    {file = "grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2"},
-    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de"},
-    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921"},
-    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411"},
-    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd"},
-    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f"},
-    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f"},
-    {file = "grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193"},
-    {file = "grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff"},
-    {file = "grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad"},
-    {file = "grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0"},
-    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f"},
-    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6"},
-    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140"},
-    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d"},
-    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7"},
-    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7"},
-    {file = "grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294"},
-    {file = "grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50"},
-    {file = "grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e"},
-    {file = "grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f"},
-    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9"},
-    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14"},
-    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05"},
-    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1"},
-    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f"},
-    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e"},
-    {file = "grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae"},
-    {file = "grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f"},
-    {file = "grpcio-1.80.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:aacdfb4ed3eb919ca997504d27e03d5dba403c85130b8ed450308590a738f7a4"},
-    {file = "grpcio-1.80.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a361c20ec1ccd3c3953d20fb6d7b4125093bdd10dff44c5e2bbb39e58917cedc"},
-    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:43168871f170d1e4ed16ae03d10cd21efa29f190e710a624cee7e5ae07da6f4f"},
-    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1b97cd29a8eda100b559b455331c487a80915b6ea6bd91cf3e89836c4ee8d957"},
-    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bac1d573dfa84ce59a5547073e28fa7326d53352adda6912e362da0b917fcef4"},
-    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4560cf0e86514595dbbd330cd65b7afad4b5c4b8c4905c041cfffa138d45e6fd"},
-    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ec0a592e926071b4abad50c1495cd0d0d513324b3ff5e7267067c33ba27506e4"},
-    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:deb10a1528473c11f72a0939eed36d83e847d7cbb63e8cc5611fb7a912d38614"},
-    {file = "grpcio-1.80.0-cp39-cp39-win32.whl", hash = "sha256:627fb7312171cdc52828bd6fac8d7028ff2a64b89f1957b6f3416caa2218d141"},
-    {file = "grpcio-1.80.0-cp39-cp39-win_amd64.whl", hash = "sha256:05d55e1798756282cddd52d56c896b3e7d673e3a8798c2f1cd05ba249a3bb4de"},
-    {file = "grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257"},
+    {file = "grpcio-1.81.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:6f9a0c9c1cc15c112d1c053064fd032b64917062292c3d70aea280e02ae10b77"},
+    {file = "grpcio-1.81.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:69ef28e54fc85397f91b8c19592b8ef3d81952080366914823bd8572a2958120"},
+    {file = "grpcio-1.81.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:15641444eca4a29358107b3dceb74c1c6305c55c822fd199b458aaea4068a7fb"},
+    {file = "grpcio-1.81.1-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d4b2dddfc219f54f956ccd53cf76a1d338ffe68fc7f2849ec9c7feb9927ff692"},
+    {file = "grpcio-1.81.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca1cc11d82677b9662082e5478b7528e2b7db7beaa6bdff42bd62789d81be399"},
+    {file = "grpcio-1.81.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa2ba7d2ad6df4d80127cea65e5b8d5e2c3adbf153ff4804452836328aca7c54"},
+    {file = "grpcio-1.81.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:592b5fee597faa91cce2dd294dd7d9a1c83d76c4dbf877e33ec1adb866b2fbed"},
+    {file = "grpcio-1.81.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:62481553b1793a27e9b9c3cf9e5bd483ef045ca72462592074b46d42b0c4d9b9"},
+    {file = "grpcio-1.81.1-cp310-cp310-win32.whl", hash = "sha256:bb693b1e3d9a2f3fd228e2110daf4b5aeedb36761ca1e4282f74725f6d89f611"},
+    {file = "grpcio-1.81.1-cp310-cp310-win_amd64.whl", hash = "sha256:88268ca418cacea64cecb0d1d600d3c6b3a8038fcba02e1e205178c5b1f47661"},
+    {file = "grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f"},
+    {file = "grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137"},
+    {file = "grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a"},
+    {file = "grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49"},
+    {file = "grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2"},
+    {file = "grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416"},
+    {file = "grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70"},
+    {file = "grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad"},
+    {file = "grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5"},
+    {file = "grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79"},
+    {file = "grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115"},
+    {file = "grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3"},
+    {file = "grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2"},
+    {file = "grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7"},
+    {file = "grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0"},
+    {file = "grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3"},
+    {file = "grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf"},
+    {file = "grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c"},
+    {file = "grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6"},
+    {file = "grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94"},
+    {file = "grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe"},
+    {file = "grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e"},
+    {file = "grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0"},
+    {file = "grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14"},
+    {file = "grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae"},
+    {file = "grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5"},
+    {file = "grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb"},
+    {file = "grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7"},
+    {file = "grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42"},
+    {file = "grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60"},
+    {file = "grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b"},
+    {file = "grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e"},
+    {file = "grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27"},
+    {file = "grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854"},
+    {file = "grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6"},
+    {file = "grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5"},
+    {file = "grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0"},
+    {file = "grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190"},
+    {file = "grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f"},
+    {file = "grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821"},
+    {file = "grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b"},
 ]
 
 [package.dependencies]
 typing-extensions = ">=4.12,<5.0"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.80.0)"]
+protobuf = ["grpcio-tools (>=1.81.1)"]
 
 [[package]]
 name = "gunicorn"
@@ -1161,14 +1148,14 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
-    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
@@ -2216,14 +2203,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]
@@ -2255,14 +2242,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
-    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
+    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
 ]
 
 [package.dependencies]
@@ -2270,20 +2257,17 @@ cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryp
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -2348,14 +2332,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.2"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da"},
-    {file = "python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3"},
+    {file = "python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500"},
+    {file = "python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690"},
 ]
 
 [package.dependencies]
@@ -2383,14 +2367,14 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.29"
+version = "0.0.32"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69"},
-    {file = "python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904"},
+    {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
+    {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
 ]
 
 [[package]]
@@ -2509,20 +2493,20 @@ files = [
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "7.4.1"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec"},
-    {file = "redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad"},
+    {file = "redis-7.4.1-py3-none-any.whl", hash = "sha256:1fa4647af1c5e93a2c685aa248ee44cce092691146d41390518dabe9a99839b0"},
+    {file = "redis-7.4.1.tar.gz", hash = "sha256:1a1df5067062cf7cbe677994e391f8ee0840f499d370f1a71266e0dd3aa9308e"},
 ]
 
 [package.extras]
 circuit-breaker = ["pybreaker (>=1.4.0)"]
 hiredis = ["hiredis (>=3.2.0)"]
-jwt = ["pyjwt (>=2.9.0)"]
+jwt = ["pyjwt (>=2.13.0)"]
 ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
 otel = ["opentelemetry-api (>=1.39.1)", "opentelemetry-exporter-otlp-proto-http (>=1.39.1)", "opentelemetry-sdk (>=1.39.1)"]
 xxhash = ["xxhash (>=3.6.0,<3.7.0)"]
@@ -2816,30 +2800,30 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.15.15"
+version = "0.15.18"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b"},
-    {file = "ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e"},
-    {file = "ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4"},
-    {file = "ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c"},
-    {file = "ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd"},
-    {file = "ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f"},
-    {file = "ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb"},
-    {file = "ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a"},
-    {file = "ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9"},
-    {file = "ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4"},
-    {file = "ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7"},
-    {file = "ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6"},
+    {file = "ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df"},
+    {file = "ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2"},
+    {file = "ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d"},
+    {file = "ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1"},
+    {file = "ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff"},
+    {file = "ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22"},
+    {file = "ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809"},
+    {file = "ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a"},
+    {file = "ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4"},
+    {file = "ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3"},
+    {file = "ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4"},
+    {file = "ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33"},
 ]
 
 [[package]]
@@ -2860,20 +2844,20 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "semgrep"
-version = "1.164.0"
+version = "1.167.0"
 description = "Lightweight static analysis for many languages. Find bug variants with patterns that look like source code."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_10_14_x86_64.whl", hash = "sha256:3b4912696a2ee467a8568d5430fe09da6e1101039052a03e606dcf68ebe37c0a"},
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:02c2b10395a6cb7344409d244baca5137dddd16f3a7bd178f786a2224c32adc0"},
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_aarch64.whl", hash = "sha256:376e04f713b244eee95e8a51b3e81240cda7c07136d7819f727b5ca07ec7eca9"},
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_x86_64.whl", hash = "sha256:745ae5ce1bef7c9b03c92b431d174ca6ee7801a5e2a047c64ac2104c7e6952fb"},
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_aarch64.whl", hash = "sha256:341d3b32dbb652dcaa5ebe6f47f2bf79af1555bf357f2e14b2c54553b59e30d6"},
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ad8550639c9f7881d9551919b09aab86cfd0464417f113cfd6290d9f9cfcc4d"},
-    {file = "semgrep-1.164.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:f0fc972bd0e33893ef73e8144c2c2293f7acafa86c00cca4e22673bc1b6c35ca"},
-    {file = "semgrep-1.164.0.tar.gz", hash = "sha256:a197bda58931d2e223e2ab7e45c3fd7b9ac37abd69516184ae09f1512f2d9b12"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_10_14_x86_64.whl", hash = "sha256:7d8b222f13a947c164e6b89e64258474c0fd59c08bfd1071ed7b3216afcd8cf6"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:ca5ba16bd2bf7a3e305a32ad292f66246947d31c41603b580453acd7ab859827"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_aarch64.whl", hash = "sha256:a4912d2af1371ad96524163ec10842227fcc79dd14fd8b6a706d598bf380fcbc"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-manylinux_2_34_x86_64.whl", hash = "sha256:687f08c3c3951bcc6f67d63cc0019c40401c900ecc26a6e56382b6cc02f4f50f"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_aarch64.whl", hash = "sha256:e7d82cc6b5eb8bd699b2a329e6c11de7ba039643c69c1b61150cda1298585aee"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-musllinux_1_2_x86_64.whl", hash = "sha256:912be28e47409bb1c53d1a4512f2a39ac9e693c7895cb94d8c181702c8bed837"},
+    {file = "semgrep-1.167.0-cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:b01823d9b540cccb92e09a404ee796f5fe2a28c132170967386909e3b77f5b8e"},
+    {file = "semgrep-1.167.0.tar.gz", hash = "sha256:7ee779321c3a8580ba1192d4933422ae29f8802ca38edcbfa942ce0a97592ac1"},
 ]
 
 [package.dependencies]
@@ -2893,7 +2877,7 @@ opentelemetry-instrumentation-threading = ">=0.58b0,<1.0"
 opentelemetry-sdk = ">=1.37.0,<1.38.0"
 packaging = ">=21.0"
 peewee = ">=3.14,<4.0"
-pyjwt = {version = ">=2.12.0,<2.13.0", extras = ["crypto"]}
+pyjwt = {version = ">=2.13.0,<2.14.0", extras = ["crypto"]}
 pywin32 = {version = "311", markers = "sys_platform == \"win32\""}
 requests = ">=2.22,<3.0"
 rich = ">=13.5.2"
@@ -2970,14 +2954,14 @@ uvicorn = ["uvicorn (>=0.34.0)"]
 
 [[package]]
 name = "starlette"
-version = "1.2.0"
+version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7"},
-    {file = "starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [package.dependencies]
@@ -2985,7 +2969,7 @@ anyio = ">=3.6.2,<5"
 typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "tomli"
@@ -3128,15 +3112,15 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "uvicorn"
-version = "0.48.0"
+version = "0.49.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "sys_platform != \"emscripten\""
 files = [
-    {file = "uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad"},
-    {file = "uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37"},
+    {file = "uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f"},
+    {file = "uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3"},
 ]
 
 [package.dependencies]
@@ -3144,25 +3128,25 @@ click = ">=7.0"
 h11 = ">=0.8"
 
 [package.extras]
-standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.20)", "websockets (>=10.4)"]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.8.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.20)", "websockets (>=10.4)"]
 
 [[package]]
 name = "virtualenv"
-version = "21.4.1"
+version = "21.5.1"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.4.1-py3-none-any.whl", hash = "sha256:caf4ff72d1b4039057f41d8e8466e859513d67c0400d9c6b62c02c9d1ebc3e12"},
-    {file = "virtualenv-21.4.1.tar.gz", hash = "sha256:2ca543c713b72840ceffd94e9bdedfbd09a661defa1f7f69e5429ad4059442e2"},
+    {file = "virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783"},
+    {file = "virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1.4"
+python-discovery = ">=1.4.2"
 
 [[package]]
 name = "wcmatch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,34 @@ exclude = [
     "reference",
 ]
 
+# Production source code must be fully annotated.
+[[tool.mypy.overrides]]
+module = [
+    "apps.accounts.*",
+    "apps.classifieds.*",
+    "apps.cms.*",
+    "apps.core.*",
+    "apps.directory.*",
+    "apps.events.*",
+    "apps.forums.*",
+    "apps.indexing.*",
+    "apps.resources.*",
+    "apps.search.*",
+    "apps.webhooks.*",
+    "cityforge.*",
+    "indexer.*",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+# Tests are checked, but we do not require every test helper to be fully annotated.
+[[tool.mypy.overrides]]
+module = [
+    "apps.*.tests",
+]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
 [tool.django-stubs]
 django_settings_module = "cityforge.settings"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cityforge"
-version = "2.0.10"
+version = "2.0.11"
 description = "Community platform: business directory, forums, classifieds, and resources built on Django."
 authors = ["CityForge contributors"]
 license = "See LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ ruff = ">=0.5"
 semgrep = ">=1.70"
 pre-commit = ">=3.7"
 pytest-cov = "^7.1.0"
+mypy = "^2.1.0"
+django-stubs = {extras = ["compatible-mypy"], version = "^6.0.5"}
 
 [build-system]
 requires = ["poetry-core>=1.8.0"]
@@ -48,6 +50,24 @@ extend-exclude = ["migrations", ".venv", "reference"]
 select = ["E", "F", "W", "I", "UP", "B", "DJ"]
 # Legacy Prisma imports preserve nullable string columns from the source schema.
 ignore = ["E501", "DJ001"]
+
+[tool.mypy]
+python_version = "3.12"
+plugins = ["mypy_django_plugin.main"]
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+check_untyped_defs = true
+show_error_codes = true
+ignore_missing_imports = true
+exclude = [
+    "migrations",
+    ".venv",
+    "reference",
+]
+
+[tool.django-stubs]
+django_settings_module = "cityforge.settings"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "cityforge.settings"

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,14 +37,14 @@
           <a href="{% url 'events:home' %}">Events</a>
           <a href="{% url 'search:search' %}">Web Search</a>
           {% if user.is_authenticated %}
-            <a href="{% url 'directory:card_submit' %}">Submit Business</a>
-            <a href="{% url 'events:submit' %}">Submit Event</a>
             <details class="account-menu">
             <summary class="user-chip">{{ user.first_name|default:user.email }}</summary>
             <div class="account-menu-panel">
               {% if user.is_admin or user.is_staff or user.is_support %}
                 <a href="{% url 'cms:dashboard' %}">Manage</a>
               {% endif %}
+              <a href="{% url 'directory:card_submit' %}">Submit Business</a>
+              <a href="{% url 'events:submit' %}">Submit Event</a>
               <a href="{% url 'directory:my_submissions' %}">My submissions</a>
               <button id="theme-toggle" type="button" class="theme-toggle" aria-label="Theme">Theme</button>
               <form action="{% url 'accounts:logout' %}" method="post">

--- a/tests/e2e/test_critical_flows.py
+++ b/tests/e2e/test_critical_flows.py
@@ -106,7 +106,8 @@ class CriticalJourneyE2ETests(TestCase):
                 self.assertEqual(submit.headers["Location"], reverse("directory:home"))
                 submission = CardSubmission.objects.get(name="Flow Submission")
                 self.assertEqual(submission.status, CardSubmissionStatus.PENDING)
-                saved_path = Path(media_root) / submission.image_url.removeprefix("/media/")
+                image_url = submission.image_url or ""
+                saved_path = Path(media_root) / image_url.removeprefix("/media/")
                 self.assertTrue(saved_path.exists())
 
                 self.client.force_login(admin)

--- a/tests/e2e/test_platform_journeys.py
+++ b/tests/e2e/test_platform_journeys.py
@@ -4,6 +4,7 @@ import json
 from datetime import timedelta
 from io import BytesIO
 from tempfile import TemporaryDirectory
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -43,7 +44,7 @@ def _set_captcha(client, scope: str, answer: str = "7") -> str:
     return answer
 
 
-def _auth_header(token: str) -> dict[str, str]:
+def _auth_header(token: str) -> dict[str, Any]:
     return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
 
@@ -256,6 +257,7 @@ class DirectoryAndCmsE2ETests(TestCase):
                 submission = CardSubmission.objects.get(name="Journey Cafe")
                 self.assertEqual(submission.status, CardSubmissionStatus.PENDING)
 
+                assert submission.image_url is not None
                 uploaded = self.client.get(submission.image_url)
                 self.assertEqual(uploaded.status_code, 200)
                 self.assertEqual(uploaded.headers["Content-Type"], "image/png")

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -13,8 +13,9 @@ def _load_indexer_module():
         spec = importlib.util.spec_from_file_location(
             "cityforge_indexer", indexer_dir / "indexer.py"
         )
+        assert spec is not None
         module = importlib.util.module_from_spec(spec)
-        assert spec and spec.loader
+        assert spec.loader is not None
         spec.loader.exec_module(module)
         return module
     finally:


### PR DESCRIPTION
- Install mypy and django-stubs as dev dependencies
- Configure mypy in pyproject.toml (check_untyped_defs, warn_unused_ignores, etc.)
- Fix 111 type errors across 16 files:
  - Narrow AnonymousUser unions in views with assertions
  - Add null-guards for nullable fields in tests
  - Fix dict invariance and QuerySet annotation issues
  - Resolve Any returns and missing type annotations
- Add mypy to pre-commit hooks and GitHub Actions CI