### PR TITLE
Potential fix for code scanning alert no. 2546: URL redirection from remote source

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -432,13 +432,15 @@ def login_view(request: HttpRequest) -> HttpResponse:
             else:
                 login(request, user)
                 next_url = request.GET.get("next")
-                if not url_has_allowed_host_and_scheme(
+                if next_url and url_has_allowed_host_and_scheme(
                     next_url,
                     allowed_hosts={request.get_host()},
                     require_https=request.is_secure(),
                 ):
-                    next_url = reverse("directory:home")
-                return redirect(next_url or "directory:home")
+                    safe_next_url = next_url
+                else:
+                    safe_next_url = reverse("directory:home")
+                return redirect(safe_next_url)
     else:
         form = LoginForm()
     return render(request, "accounts/login.html", {"form": form})


### PR DESCRIPTION
Potential fix for [https://github.com/SmolTech/CityForge/security/code-scanning/2546](https://github.com/SmolTech/CityForge/security/code-scanning/2546)

General fix: never pass raw request parameters directly to `redirect`; instead, derive a separate `safe_next_url` that is only assigned from trusted values (validated `next` or a fixed internal fallback), and redirect using that variable.

Best fix for this file/region: in `apps/accounts/views.py` inside `login_view` (around lines 434–441), keep the existing host/scheme validation, but compute a new `safe_next_url` and pass only that to `redirect`. This preserves functionality (honors valid `next`, otherwise goes home) while making the trust boundary explicit.

No new dependencies are needed. Existing imports already include `url_has_allowed_host_and_scheme` and `reverse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
